### PR TITLE
Fix incorrectly captured value in closure in KeyAssignedListView example

### DIFF
--- a/examples/keyassignedlistview.py
+++ b/examples/keyassignedlistview.py
@@ -6,7 +6,7 @@ class BasicScene(UIScene):
     def __init__(self):
         button_generator = (ButtonView(
             text="Item {}".format(i),
-            callback=lambda: print("Called Item {}".format(i)))
+            callback=lambda x=i: print("Called Item {}".format(x)))
             for i in range(0, 100)
         )
         self.key_assign = KeyAssignedListView(


### PR DESCRIPTION
The keyassignedlistview.py example was always printing "Item 99", due to the way Python lambdas capture lexical scope. This fixes that by binding the variable (i) as the default value to another variable (x) inside the closure.