### PR TITLE
Add docstrings for KeyAssignedListView and ScrollingTextView classes

### DIFF
--- a/clubsandwich/ui/collection_list.py
+++ b/clubsandwich/ui/collection_list.py
@@ -158,20 +158,37 @@ class SettingsListView(FirstResponderContainerView):
             self.find_next_responder()
             return True
         # pageup/<
-        elif val == terminal.TK_PAGEUP or val == terminal.TK_COMMA and blt_state.shift:
+        elif (val == terminal.TK_PAGEUP
+              or val == terminal.TK_COMMA
+              and blt_state.shift):
             self.min_row = max(0, self.min_row - self.inner_height)
             self.set_first_responder_in_visible_area()
             return True
         # pagedown/>
-        elif val == terminal.TK_PAGEDOWN or val == terminal.TK_PERIOD and blt_state.shift:
+        elif (val == terminal.TK_PAGEDOWN
+              or val == terminal.TK_PERIOD
+              and blt_state.shift):
             self.min_row = min(
-                len(self.labels) - self.inner_height - 1, self.min_row + self.inner_height)
+                len(self.labels) - self.inner_height - 1,
+                self.min_row + self.inner_height)
             self.set_first_responder_in_visible_area()
             return True
 
 
 class KeyAssignedListView(SettingsListView):
-    CHARACTER_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"#$%?&*()_+^:'.|{}[]@"
+    """ ListView element where each item is assigned to a input value on the
+    keyboard.
+    
+    :param value_controls: list of items which will be assigned a specific
+    character as their input key.
+    :param value_column_width: int width for a List Item string.
+    :param args:
+    :param kwargs:
+    """
+    CHARACTER_SET = (
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz"
+        "0123456789!\"#$%?&*()_+^:'.|{}[]@")
 
     def __init__(self, value_controls, value_column_width=16, *args, **kwargs):
         symbols = (symbol for symbol in self.CHARACTER_SET)
@@ -179,7 +196,10 @@ class KeyAssignedListView(SettingsListView):
         for value_control in value_controls:
             label_control_pairs.append((next(symbols, " "), value_control))
 
-        super().__init__(label_control_pairs, value_column_width=16, *args, **kwargs)
+        super().__init__(label_control_pairs,
+                         value_column_width=16,
+                         *args,
+                         **kwargs)
 
     def terminal_read(self, val):
         super().terminal_read(val)

--- a/clubsandwich/ui/firstrespondercontainerview.py
+++ b/clubsandwich/ui/firstrespondercontainerview.py
@@ -37,7 +37,8 @@ class FirstResponderContainerView(View):
 
     def _first_responder_traversal(self, v):
         if v.contains_first_responders:
-            # this view may always become the first responder because it will manage
+            # this view may always become the first responder
+            # because it will manage
             # inner first responders, but do not try to look inside it.
             yield v
             return

--- a/clubsandwich/ui/scrollingtextview.py
+++ b/clubsandwich/ui/scrollingtextview.py
@@ -33,6 +33,10 @@ class ScrollingTextView(View):
         return True
 
     def add_lines(self, lines_string):
+        """
+        Add additional lines of text to this view and refocus if needed.
+        :param lines_string: New lines to add.
+        """
         unwrapped_lines = lines_string.splitlines(keepends=True)
         wrapped_lines = []
         for line in unwrapped_lines:
@@ -42,7 +46,8 @@ class ScrollingTextView(View):
 
         self.list_of_strings.extend(wrapped_lines)
         lines_added = len(wrapped_lines)
-        if self.top_line_index + self.lines_to_display <= len(self.list_of_strings) - lines_added:
+        if (self.top_line_index + self.lines_to_display <= len(
+                self.list_of_strings) - lines_added):
             if lines_added > self.lines_to_display:
                 focus_substract = lines_added
             else:
@@ -53,20 +58,36 @@ class ScrollingTextView(View):
             self._refocus()
 
     def focus_on_line(self, line_index):
+        """
+        Move the selected line index to the top of the view area. Which sets
+        the viewable buffer to line_index + lines.
+        :param line_index: Index (int) of line to focus. Negative values
+        will default to first line.
+        """
         self.top_line_index = line_index if line_index >= 0 else 0
         self._refocus()
 
     def scroll_up(self):
+        """
+        Shifts the viewable lines buffer up by one line.
+        """
         if self.top_line_index > 0:
             self.top_line_index -= 1
             self._refocus()
 
     def scroll_down(self):
+        """
+        Shifts the viewable lines buffer down by one line.
+        """
         if self.top_line_index + self.lines_to_display < len(self.list_of_strings):
             self.top_line_index += 1
             self._refocus()
 
     def _refocus(self):
+        """
+        Updates the label text to show the lines between self.top_line_index
+        and self.lines_to_display.
+        """
         new_view_lines = "\n".join(
             self.list_of_strings[self.top_line_index:
                                  self.top_line_index + self.lines_to_display]
@@ -75,10 +96,12 @@ class ScrollingTextView(View):
 
     @property
     def intrinsic_size(self):
+
         # add space for arrows
         return self.label_view.intrinsic_size + Size(4, 0)
 
     def set_needs_layout(self, val=True):
+        """ See `:py:class:`View` for details. """
         super().set_needs_layout(val)
         self.label_view.set_needs_layout(val)
 


### PR DESCRIPTION
@irskep I added the missing docstrings for the `KeyAssignedListView` and `ScrollingTextView` classes. However I'm not familiar enough with sphinx to go about generating the `.rst` files needed for the docs site so I haven't made any changes there. (Im not even sure, do those need to be updated?)

I did some slight reformatting to a few places pylint complained about long lines, strictly formatting no logical changes.