### PR TITLE
Use fps argument in BearLibTerminalEventLoop for real

### DIFF
--- a/clubsandwich/blt/loop.py
+++ b/clubsandwich/blt/loop.py
@@ -38,7 +38,7 @@ class BearLibTerminalEventLoop:
         MyDemo().run()
     """
 
-    def __init__(self, fps=72):
+    def __init__(self, fps=80):
         super().__init__()
         self.fps = fps
 
@@ -89,7 +89,7 @@ class BearLibTerminalEventLoop:
             has_run_one_loop = False
             while self.run_loop_iteration():
                 has_run_one_loop = True
-                time.sleep(1 / 80)
+                time.sleep(1 / self.fps)
             if not has_run_one_loop:
                 print(
                     "Exited after only one loop iteration. Did you forget to" +

--- a/clubsandwich/director.py
+++ b/clubsandwich/director.py
@@ -73,8 +73,8 @@ class DirectorLoop(BearLibTerminalEventLoop):
         If truthy, the loop will exit at the end of the frame.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, fps=80):
+        super().__init__(fps)
         self.should_exit = False
         self.scene_stack = []
         self.ctx = BearLibTerminalContext()


### PR DESCRIPTION
Currently, the frame refresh rate is fixed at 80fps irrespective of the fps parameter provided to the BearLibTerminalEventLoop constructor.
This also adds fps as a parameter to DirectorLoop's constructor, and changes the default value to 80, which was used in BLTEL the whole time.