### PR TITLE
Fix LabelView.debug_string

### DIFF
--- a/clubsandwich/ui/misc_views.py
+++ b/clubsandwich/ui/misc_views.py
@@ -131,8 +131,9 @@ class LabelView(View):
 
         ctx.print(Point(x, y).floored, self.text)
 
+    @property
     def debug_string(self):
-        return super().debug_string() + ' ' + repr(self.text)
+        return super().debug_string + ' ' + repr(self.text)
 
 
 class ButtonView(View):


### PR DESCRIPTION
`View.debug_string` is implemented as a property, but it seems LabelView treated it as a regular method.
Fixes #19 