### PR TITLE
Fix FirstResponderContainerView.remove_subviews

### DIFF
--- a/clubsandwich/ui/firstrespondercontainerview.py
+++ b/clubsandwich/ui/firstrespondercontainerview.py
@@ -55,7 +55,7 @@ class FirstResponderContainerView(View):
     def remove_subviews(self, subviews):
         super().remove_subviews(subviews)
         for v in subviews:
-            for sv in self.first_responder_traversal(v):
+            for sv in self._first_responder_traversal(v):
                 if sv == self.first_responder:
                     self.set_first_responder(None)
                     self.find_next_responder()


### PR DESCRIPTION
I ran into a traceback when trying to remove a subview from a scene's view:
```
...
File "/home/carl/Programming/Python/cyberogue/core/systems.py", line 192, in _close_dialog
    self.view.remove_subview(lab)
File "/home/carl/Programming/Python/clubsandwich/clubsandwich/ui/view.py", line 131, in remove_subview
    self.remove_subviews([subview])
File "/home/carl/Programming/Python/clubsandwich/clubsandwich/ui/firstrespondercontainerview.py", line 58, in remove_subviews
    for sv in self.first_responder_traversal(v):
TypeError: first_responder_traversal() takes 1 positional argument but 2 were given
```
I think the wrong version of `first_responder_traversal` is being called. 